### PR TITLE
fix(types): allow ReactNode type for list item icons

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { ConfigContext, DocumentOptions, SanityDocument } from 'sanity';
 import { StructureBuilder } from 'sanity/structure';
-import { ComponentType } from 'react';
+import { ComponentType, ReactNode } from 'react';
 
 export interface SingletonDocumentListItemConfig {
   S: StructureBuilder;
@@ -8,7 +8,7 @@ export interface SingletonDocumentListItemConfig {
   type: string;
   title?: string;
   id?: string;
-  icon?: ComponentType;
+  icon?: ComponentType | ReactNode;
 }
 
 export interface SingletonPluginListItemsConfig {


### PR DESCRIPTION
There's a small issue with the `SingletonDocumentListItemConfig` interface. The `icon` property currently only allows `ComponentType` while the `ListItemBuilder` actually allows `ReactNode | ComponentType`:

<img width="729" alt="Screenshot 2024-05-15 at 08 39 35" src="https://github.com/plsrd/sanity-plugin-singleton-tools/assets/1009069/25d805bc-0cc2-40be-a682-f6aa00399578">

In my project I'm re-using the schema definition when building the structure so I don't have to repeat any config, but this means I currently need to add the `as ComponentType` for the types to match:

<img width="504" alt="Screenshot 2024-05-15 at 08 40 19" src="https://github.com/plsrd/sanity-plugin-singleton-tools/assets/1009069/516d1341-b82f-4592-a257-f9600d7c62c4">

This PR fixes this minor inconvenience. 😊 