### PR TITLE
fix: package version not updated after recent changes (and a few other changes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "sanity-plugin-singleton",
-  "version": "1.0.0",
+  "name": "sanity-plugin-singleton-tools",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sanity-plugin-singleton",
-      "version": "1.0.0",
+      "name": "sanity-plugin-singleton-tools",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^2.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-singleton-tools",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A plugin to create and manage singletons in your Sanity Studio",
   "keywords": [
     "sanity",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,5 @@
-import { DocumentActionsContext, DocumentActionsResolver } from 'sanity';
-import { getIsSingleton } from './helpers';
+import { DocumentActionsContext, DocumentActionsResolver } from "sanity";
+import { getIsSingleton } from "./helpers";
 
 export const actions: DocumentActionsResolver = (
   prev,
@@ -7,9 +7,7 @@ export const actions: DocumentActionsResolver = (
 ) => {
   return getIsSingleton(schema, schemaType)
     ? prev.filter(({ action }) =>
-        ['publish', 'unpublish', 'discardChanges', 'restore'].includes(
-          action as string
-        )
+        ["publish", "discardChanges", "restore"].includes(action as string)
       )
     : prev;
 };

--- a/src/structure/index.ts
+++ b/src/structure/index.ts
@@ -1,9 +1,9 @@
-import { getSingletonDocuments } from '../helpers';
-import { DocumentIcon } from '@sanity/icons';
+import { getSingletonDocuments } from "../helpers";
+import { DocumentIcon } from "@sanity/icons";
 import {
   SingletonDocumentListItemConfig,
   SingletonPluginListItemsConfig,
-} from '../types';
+} from "../types";
 
 const singletonDocumentListItem = (config: SingletonDocumentListItemConfig) => {
   if (!config?.S || !config?.type || !config.context) {
@@ -37,8 +37,10 @@ const singletonDocumentListItems = (config: SingletonPluginListItemsConfig) => {
 
   const singletons = getSingletonDocuments(schema);
 
-  return singletons?.map(schemaType =>
-    singletonDocumentListItem({ S, context, type: schemaType })
+  return (
+    singletons?.map((schemaType) =>
+      singletonDocumentListItem({ S, context, type: schemaType })
+    ) || []
   );
 };
 
@@ -55,7 +57,7 @@ const filteredDocumentListItems = (config: SingletonPluginListItemsConfig) => {
   const singletons = getSingletonDocuments(schema);
 
   return S.documentTypeListItems().filter(
-    type => singletons && !singletons.includes(type.getId() as string)
+    (type) => singletons && !singletons.includes(type.getId() as string)
   );
 };
 


### PR DESCRIPTION
This PR has the following changes:
1. Fixed the return type of `singletonDocumentListItems`  to ensure it does not return `undefined`
2. Remove `unpublish` from allowed singleton actions (addresses #2 )
3. Bumps the package version since I noticed that the recent changes have not been published to the npm package yet (like the icon fix)